### PR TITLE
Create working 1.44MB floppy image for old OSes. Fixes packer issue#2421

### DIFF
--- a/fat/super_floppy.go
+++ b/fat/super_floppy.go
@@ -72,15 +72,25 @@ func (f *superFloppyFormatter) format() error {
 			label = "FAT16   "
 		}
 
-		// Determine the number of root directory entries
-		if f.device.Len() > 512*5*32 {
-			bsCommon.RootEntryCount = 512
+		// For 1.44MB Floppy, for other floppy formats see https://support.microsoft.com/en-us/kb/75131.
+		// We make an exception for this most common usecase as the calculations don't create a working image for older operating systems
+		if f.config.FATType == FAT12 && f.device.Len() == 1474560 {
+				bsCommon.RootEntryCount = 224
+				bsCommon.SectorsPerFat = 9
+				bsCommon.SectorsPerTrack = 18
+				bsCommon.Media = 240
+				bsCommon.NumHeads = 2
 		} else {
-			bsCommon.RootEntryCount = uint16(f.device.Len() / (5 * 32))
+			// Determine the number of root directory entries
+			if f.device.Len() > 512*5*32 {
+				bsCommon.RootEntryCount = 512
+			} else {
+				bsCommon.RootEntryCount = uint16(f.device.Len() / (5 * 32))
+			}
+
+			bsCommon.SectorsPerFat = f.sectorsPerFat(bsCommon.RootEntryCount, sectorsPerCluster)
 		}
-
-		bsCommon.SectorsPerFat = f.sectorsPerFat(bsCommon.RootEntryCount, sectorsPerCluster)
-
+			
 		bs := &BootSectorFat16{
 			BootSectorCommon:    bsCommon,
 			FileSystemTypeLabel: label,


### PR DESCRIPTION
Because I couldn't use packer without workarounds to build old OS'es like Windows 2000 and 2003 like described in packer issue#2421 I decided to spend some time to support these great OS'es :-).
It took quite some time and digging into fat, go, comparing disk images but in the end it's the root entries, sectors per fat and sectors per track that made the difference. Left out the sector marking as it didn't make any difference in the workings for the old OS'es.
Added it as an exception as I don't know if it's actually possible to get the proper values using the existing calculations of the values and not breaking any other sized devices.
Checked this using Windows 2000, Windows 2003 and verified it still works on 2008 and 2016TP5 as well.
Created a seperate issue for this in go-fs as well. Fixes #11 
