### PR TITLE
fat: ensure that DecodeDirectoryClusterEntry(...) removes the trailing whitespace from it's 8.3 name so that "." and ".." don't get treated as regular filenames with an extension.

### DIFF
--- a/fat/directory_cluster.go
+++ b/fat/directory_cluster.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"time"
 	"unicode/utf16"
+	"strings"
 )
 
 type DirectoryAttr uint8
@@ -341,8 +342,8 @@ func DecodeDirectoryClusterEntry(data []byte) (*DirectoryClusterEntry, error) {
 			data[0] = 0xE5
 		}
 
-		result.name = string(data[0:8])
-		result.ext = string(data[8:11])
+		result.name = strings.TrimRight(string(data[0:8]), " ")
+		result.ext = strings.TrimRight(string(data[8:11]), " ")
 
 		// Creation time
 		createTimeTenths := data[13]


### PR DESCRIPTION
fat: ensure that DecodeDirectoryClusterEntry(...) removes the trailing whitespace from it's name.

This prevents DirectoryEntry.ShortName() and DirectoryClusterEntry.Bytes() from considering the . and .. directories as 8.3 filenames to split instead of the special cased entries that they are.

This fixes issue #9. 
