### PR TITLE
Added the case for dealing with short names when the extension itself is larger than 3 characters and the total filename length is less than 11

### DIFF
--- a/fat/short_name.go
+++ b/fat/short_name.go
@@ -42,7 +42,7 @@ func generateShortName(longName string, used []string) (string, error) {
 		simpleName = simpleName[0 : len(simpleName)-1]
 	}
 
-	doSuffix := name != rawName || len(name) > 8
+	doSuffix := name != rawName || len(name) > 8 || len(ext) > 3
 	if !doSuffix {
 		for _, usedSingle := range used {
 			if strings.ToUpper(usedSingle) == simpleName {
@@ -53,6 +53,9 @@ func generateShortName(longName string, used []string) (string, error) {
 	}
 
 	if doSuffix {
+		if len(ext) > 3 {
+			ext = ext[:3]
+		}
 		found := false
 		for i := 1; i < 99999; i++ {
 			serial := fmt.Sprintf("~%d", i)

--- a/fat/short_name_test.go
+++ b/fat/short_name_test.go
@@ -62,6 +62,46 @@ func TestGenerateShortName(t *testing.T) {
 	if result != ".BIG" {
 		t.Fatalf("unexpected: %s", result)
 	}
+
+	// Test valid extension
+	result, err = generateShortName("proxy.psm", []string{})
+	if err != nil {
+		t.Fatalf("err should be nil: %s", err)
+	}
+
+	if result != "PROXY.PSM" {
+		t.Fatalf("unexpected: %s", result)
+	}
+
+	// Test long extension
+	result, err = generateShortName("proxy.psm1", []string{})
+	if err != nil {
+		t.Fatalf("err should be nil: %s", err)
+	}
+
+	if result != "PROXY~1.PSM" {
+		t.Fatalf("unexpected: %s", result)
+	}
+
+	// Test short extension
+	result, err = generateShortName("proxy.x", []string{})
+	if err != nil {
+		t.Fatalf("err should be nil: %s", err)
+	}
+
+	if result != "PROXY.X" {
+		t.Fatalf("unexpected: %s", result)
+	}
+
+	// Test double shortname
+	result, err = generateShortName("proxy.x", []string{"PROXY.X", "PROXY~1.X"})
+	if err != nil {
+		t.Fatalf("err should be nil: %s", err)
+	}
+
+	if result != "PROXY~2.X" {
+		t.Fatalf("unexpected: %s", result)
+	}
 }
 
 func TestShortNameEntryValue(t *testing.T) {


### PR DESCRIPTION
Ensure that long names are generated if the extension is larger than 3 characters. Also added some testcases for those specific situations

This bug is related to hashicorp/packer#6083 and is expected to fix it.
Closes mitchellh/go-fs#5