### PR TITLE
fixes around fat32 and lfn support

### DIFF
--- a/fat/directory.go
+++ b/fat/directory.go
@@ -53,14 +53,14 @@ func DecodeDirectoryEntry(d *Directory, entries []*DirectoryClusterEntry) (*Dire
 	// We have a long entry, so we have to traverse to the point where
 	// we're done. Also, calculate out the name and such.
 	if entries[0].IsLong() {
-		lfnEntries := make([]*DirectoryClusterEntry, 0, 3)
+		lfnEntries = make([]*DirectoryClusterEntry, 0, 3)
 		for entries[0].IsLong() {
 			lfnEntries = append(lfnEntries, entries[0])
 			entries = entries[1:]
 		}
 
 		var nameBytes []rune
-		nameBytes = make([]rune, 13*len(lfnEntries))
+		nameBytes = make([]rune, 0, 13*len(lfnEntries))
 		for i := len(lfnEntries) - 1; i >= 0; i-- {
 			for _, char := range lfnEntries[i].longName {
 				nameBytes = append(nameBytes, char)

--- a/fat/filesystem.go
+++ b/fat/filesystem.go
@@ -28,7 +28,8 @@ func New(device fs.BlockDevice) (*FileSystem, error) {
 
 	var rootDir *DirectoryCluster
 	if bs.FATType() == FAT32 {
-		panic("FAT32 not implemented yet")
+		// WARNING: very experimental and incomplete
+		rootDir, err = DecodeFAT32RootDirectoryCluster(device, fat)
 	} else {
 		rootDir, err = DecodeFAT16RootDirectoryCluster(device, bs)
 		if err != nil {


### PR DESCRIPTION
This is a drive-by PR. 

I was investigating a corrupted vfat based system today and needed something to poke programmatically at the broken image. Your library was exactly the right tool (modulo some small issues that I had to tweak, see below), many thanks for it!

The image was fat32 so I added (hacky) support to get the root directory for fat32. I also fixed some issues in the lfn (long-file-name) reading. For my purposes this works well enough and I just wanted to share my fixes as they may be useful to other.

Cheers,
 Michael